### PR TITLE
Validate all files are formatted when linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,13 +9,15 @@
     "react-scripts": "3.2.0"
   },
   "scripts": {
-    "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "create:pull-request": "node scripts/issueIntoPullRequest.js",
     "eject": "react-scripts eject",
+    "format": "npm run prettier -- --write",
     "lint": "npx eslint src",
-    "format": "prettier --write \"**/*.+(js|jsx|json|yml|yaml|css|less|scss|ts|tsx|md|mdx|graphql|vue)\" \"scripts/**\"",
-    "create:pull-request": "node scripts/issueIntoPullRequest.js"
+    "prettier": "prettier \"**/*.+(js|jsx|json|yml|yaml|css|less|scss|ts|tsx|md|mdx|graphql|vue)\" \"scripts/**\"",
+    "start": "react-scripts start",
+    "test": "react-scripts test",
+    "validate": "npm run lint && npm run prettier -- --list-different"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
You can’t force everyone on your project to use the prettier integration for their editor, so let’s add a validation script to verify that prettier has been run on all project files.

Fortunately for us, Prettier accepts a --list-different flag that you can use that will throw an error when code is not up to the standard of your project.