### PR TITLE
Mock a JavaScript module in a test

### DIFF
--- a/src/helpers/math/math.test.js
+++ b/src/helpers/math/math.test.js
@@ -1,6 +1,15 @@
 // @flow strict
 import math from "./math";
 
+jest.mock("./math", () => {
+  const original = jest.requireActual("./math");
+
+  return {
+    ...original,
+    random: jest.fn((max: number): number => max - 1)
+  };
+});
+
 test("Add numbers", () => {
   const result = math.add(3, 7);
   const expected = 10;
@@ -23,14 +32,10 @@ test("Increase the number by one", () => {
 });
 
 test("Generate a random number between 0 and max - 1", () => {
-  const spy = jest.spyOn(math, "random");
-  spy.mockImplementation((max: number): number => max - 1);
   const result = math.random(1000);
   const expected = 999;
 
   expect(result).toBe(expected);
-  expect(spy).toHaveBeenCalledTimes(1);
-  expect(spy).toHaveBeenCalledWith(1000);
-
-  spy.mockRestore();
+  expect(math.random).toHaveBeenCalledTimes(1);
+  expect(math.random).toHaveBeenCalledWith(1000);
 });


### PR DESCRIPTION
So far we’re still basically monkey-patching the utils module which is fine, but could lead to problems in the future, especially if we want to mock a ESModule export which doesn’t allow this kind of monkey-patching on exports. Instead, let’s mock the entire module so when our test subject requires the file they get our mocked version instead.